### PR TITLE
Update PushType to include missing types

### DIFF
--- a/src/aapns/models.py
+++ b/src/aapns/models.py
@@ -97,6 +97,10 @@ class PushType(Enum):
 
     alert = "alert"
     background = "background"
+    voip = "voip"
+    complication = "complication"
+    fileprovider = "fileprovider"
+    mdm = "mdm"
 
 
 @attr.s


### PR DESCRIPTION
This patch adds all supported values for the `apns-push-type` header.

 * voip
 * complication
 * fileprovider
 * mdm

These are taken from Apple's [Sending Notification Requests to APNs](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns) documentation.